### PR TITLE
Pa 26 add two cols card content

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -52,7 +52,7 @@ export default function Card({ event }: Props) {
             {event_name ? event_name : "Add name"}
           </Typography>
         }
-        subheader={event_date ? event_date : "Add date"}
+        // subheader={event_date ? event_date : "Add date"}
         disableTypography
         // @ts-expect-error
         avatar={<Avatar src={creatorImage} />}
@@ -61,7 +61,11 @@ export default function Card({ event }: Props) {
       <CardContent>
         <Grid container spacing={2}>
           <Grid xs={6}>
-            <Typography variant="body1" color="text.primary" sx={{ margin: '0px' }}>
+            <Typography
+              variant="body1"
+              color="text.primary"
+              sx={{ margin: "0px" }}
+            >
               Where
             </Typography>
             <Typography
@@ -77,26 +81,14 @@ export default function Card({ event }: Props) {
               Time
             </Typography>
             <Typography variant="body2" color="text.secondary">
+              {/* {event_time ? event_time : "Add time"} */}
+              {event_date ? event_date : "Add date"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
               {event_time ? event_time : "Add time"}
             </Typography>
           </Grid>
         </Grid>
-        {/* <Typography variant="body1" mt={1} color="text.primary">
-          Where
-        </Typography>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ height: "40px", overflow: "hidden" }}
-        >
-          {event_location ? event_location : "Add location"}
-        </Typography> */}
-        {/* <Typography variant="body1" mt={2} color="text.primary">
-          Time
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {event_time ? event_time : "Add time"}
-        </Typography> */}
       </CardContent>
       <CardActions disableSpacing>
         <div style={{ display: "flex", gap: "12px" }}>

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -9,6 +9,7 @@ import {
   Avatar,
   Button,
   Typography,
+  Unstable_Grid2 as Grid,
 } from "@mui/material";
 
 type Props = {
@@ -58,7 +59,29 @@ export default function Card({ event }: Props) {
       />
       <CardMedia component="img" height="140" image={event_image} />
       <CardContent>
-        <Typography variant="body1" mt={1} color="text.primary">
+        <Grid container spacing={2}>
+          <Grid xs={6}>
+            <Typography variant="body1" color="text.primary" sx={{ margin: '0px' }}>
+              Where
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ height: "40px", overflow: "hidden" }}
+            >
+              {event_location ? event_location : "Add location"}
+            </Typography>
+          </Grid>
+          <Grid xs={6}>
+            <Typography variant="body1" color="text.primary">
+              Time
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {event_time ? event_time : "Add time"}
+            </Typography>
+          </Grid>
+        </Grid>
+        {/* <Typography variant="body1" mt={1} color="text.primary">
           Where
         </Typography>
         <Typography
@@ -67,13 +90,13 @@ export default function Card({ event }: Props) {
           sx={{ height: "40px", overflow: "hidden" }}
         >
           {event_location ? event_location : "Add location"}
-        </Typography>
-        <Typography variant="body1" mt={2} color="text.primary">
+        </Typography> */}
+        {/* <Typography variant="body1" mt={2} color="text.primary">
           Time
         </Typography>
         <Typography variant="body2" color="text.secondary">
           {event_time ? event_time : "Add time"}
-        </Typography>
+        </Typography> */}
       </CardContent>
       <CardActions disableSpacing>
         <div style={{ display: "flex", gap: "12px" }}>

--- a/src/components/header/AddEventModal.tsx
+++ b/src/components/header/AddEventModal.tsx
@@ -46,7 +46,7 @@ export default function AddEventModal({ isModalOpen, closeModal }: Props) {
       // event_description: eventDescription,
       event_description: null,
       // @ts-expect-error
-      event_date: eventDate ? eventDate.format("MMM Do (ddd)") : null,
+      event_date: eventDate ? eventDate.format("MMM Do") : null,
       event_time: eventTime ? eventTime : null,
       event_location: eventLocation ? eventLocation : null,
       event_created_by: userDocumentRef,


### PR DESCRIPTION
**What all was done:**

- Added `Grid` to card content to create two columns for event details
- Changed the date format to `Dec 12th` when new event is added
- Removed `subheader` prop from `CardHeader` and moved day/date detail into Time column in card content

**Additional**
When merged into `main`, this PR should Close #27  and Close #26.
